### PR TITLE
CurrentEnvironmentBackend

### DIFF
--- a/arca/__init__.py
+++ b/arca/__init__.py
@@ -1,8 +1,9 @@
 from ._arca import Arca
-from .backend import BaseBackend, VenvBackend, DockerBackend
+from .backend import BaseBackend, VenvBackend, DockerBackend, CurrentEnvironmentBackend, RequirementsStrategy
 from .result import Result
 from .task import Task
 
 
-__all__ = ["Arca", "BaseBackend", "VenvBackend", "DockerBackend", "Result", "Task"]
+__all__ = ["Arca", "BaseBackend", "VenvBackend", "DockerBackend", "Result", "Task", "CurrentEnvironmentBackend",
+           "RequirementsStrategy"]
 __version__ = "0.0.1"

--- a/arca/backend/__init__.py
+++ b/arca/backend/__init__.py
@@ -1,5 +1,7 @@
 from .base import BaseBackend
 from .venv import VenvBackend
 from .docker import DockerBackend
+from .current_environment import CurrentEnvironmentBackend, RequirementsStrategy
 
-__all__ = ["BaseBackend", "VenvBackend", "DockerBackend"]
+
+__all__ = ["BaseBackend", "VenvBackend", "DockerBackend", "CurrentEnvironmentBackend", "RequirementsStrategy"]

--- a/arca/backend/base.py
+++ b/arca/backend/base.py
@@ -1,14 +1,20 @@
 import hashlib
+import json
+import os
 import re
+import stat
+import subprocess
+import sys
 from pathlib import Path
 from typing import Optional, Tuple
 
 from git import Repo
 
 import arca
+from arca.exceptions import BuildError
 from arca.result import Result
 from arca.task import Task
-from arca.utils import NOT_SET, LazySettingProperty
+from arca.utils import NOT_SET, LazySettingProperty, logger
 
 
 class BaseBackend:
@@ -21,6 +27,8 @@ class BaseBackend:
         self._arca = None
         for key, val in settings.items():
             if hasattr(self, key) and isinstance(getattr(self, key), LazySettingProperty) and val is not NOT_SET:
+                if getattr(self, key).convert is not None:
+                    val = getattr(self, key).convert(val)
                 setattr(self, key, val)
 
     def inject_arca(self, arca):
@@ -63,3 +71,48 @@ class BaseBackend:
 
     def get_or_create_environment(self, repo: str, branch: str, git_repo: Repo, repo_path: Path):  # pragma: no cover
         raise NotImplementedError
+
+
+class BaseRunInSubprocessBackend(BaseBackend):
+
+    def run(self, repo: str, branch: str, task: Task, git_repo: Repo, repo_path: Path) -> Result:
+        venv_path = self.get_or_create_environment(repo, branch, git_repo, repo_path)
+
+        script_name, script = self.create_script(task, venv_path)
+        script_path = Path(self._arca.base_dir, "scripts", script_name)
+        script_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with script_path.open("w") as f:
+            f.write(script)
+
+        st = os.stat(str(script_path))
+        script_path.chmod(st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        out_stream = b""
+        err_stream = b""
+
+        cwd = str(repo_path / self.cwd)
+
+        logger.info("Running at cwd %s", cwd)
+
+        try:
+            if venv_path is not None:
+                python_path = str(venv_path.resolve() / "bin" / "python")
+            else:
+                python_path = sys.executable
+
+            process = subprocess.Popen([python_path, str(script_path.resolve())],
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE,
+                                       cwd=cwd)
+
+            out_stream, err_stream = process.communicate()
+
+            return Result(json.loads(out_stream.decode("utf-8")))
+        except Exception as e:
+            logger.exception(e)
+            raise BuildError("The build failed", extra_info={
+                "exception": e,
+                "out_stream": out_stream,
+                "err_stream": err_stream,
+            })

--- a/arca/backend/current_environment.py
+++ b/arca/backend/current_environment.py
@@ -119,4 +119,7 @@ class CurrentEnvironmentBackend(BaseRunInSubprocessBackend):
                     self.install_requirements(requirements=extra_requirements_set)
 
     def _uninstall(self, *args):
+        """ For usage in tests to uninstall packages from the current environment
+        :param args: packages to uninstall
+        """
         self.install_requirements(requirements=args, _action="uninstall")

--- a/arca/backend/current_environment.py
+++ b/arca/backend/current_environment.py
@@ -1,0 +1,122 @@
+import subprocess
+import sys
+from enum import Enum
+from pathlib import Path
+from typing import Optional, Iterable
+
+from git import Repo
+
+from arca.exceptions import ArcaMisconfigured, RequirementsMismatch, BuildError
+from arca.utils import LazySettingProperty, logger
+from .base import BaseRunInSubprocessBackend
+
+
+class RequirementsStrategy(Enum):
+    IGNORE = "ignore"
+    RAISE = "raise"
+    INSTALL_EXTRA = "install_extra"
+
+
+class CurrentEnvironmentBackend(BaseRunInSubprocessBackend):
+
+    current_environment_requirements = LazySettingProperty(key="current_environment_requirements")
+    requirements_strategy = LazySettingProperty(key="requirements_strategy",
+                                                default=RequirementsStrategy.RAISE,
+                                                convert=RequirementsStrategy)
+
+    def validate_settings(self):
+        super().validate_settings()
+
+        if self.current_environment_requirements is not None:
+            if not Path(self.current_environment_requirements).exists():
+                raise ArcaMisconfigured("Can't locate current environment requirements.")
+
+    def install_requirements(self, *, fl: Optional[Path]=None, requirements: Optional[Iterable[str]]=None,
+                             _action: str="install"):
+        if _action not in ["install", "uninstall"]:
+            raise ValueError(f"{_action} is invalid value for _invalid")
+
+        cmd = [sys.executable, "-m", "pip", _action]
+
+        if _action == "uninstall":
+            cmd += ["-y"]
+
+        if fl is not None:
+            cmd += ["-r", str(fl)]
+        elif requirements is not None:
+            cmd += list(requirements)
+        else:
+            raise ValueError("Either fl or requirements has to be provided")
+
+        logger.info("Installing requirements with command: %s", cmd)
+
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        [out_stream, err_stream] = process.communicate()
+        out_stream = out_stream.decode("utf-8")
+        err_stream = err_stream.decode("utf-8")
+
+        logger.debug("Return code is %s", process.returncode)
+        logger.debug(out_stream)
+        logger.debug(err_stream)
+
+        if process.returncode:
+            raise BuildError(f"Unable to {_action} requirements from the target repository", extra_info={
+                "out_stream": out_stream,
+                "err_stream": err_stream,
+                "returncode": process.returncode
+            })
+
+    def get_requirements_set(self, fl):
+        return set([x.strip() for x in fl.read_text().split("\n") if x.strip()])
+
+    def get_or_create_environment(self, repo: str, branch: str, git_repo: Repo, repo_path: Path):
+        """ Handles requirements difference based on configured strategy
+        """
+        if self.requirements_strategy == RequirementsStrategy.IGNORE:
+            logger.info("Requirements strategy is IGNORE")
+            return
+
+        requirements = repo_path / self.requirements_location
+
+        # explicitly configured there are no requirements for the current environment
+        if self.current_environment_requirements is None:
+
+            if not requirements.exists():
+                return  # no diff, since no requirements both in current env and repository
+
+            requirements_set = self.get_requirements_set(requirements)
+
+            if len(requirements_set):
+                if self.requirements_strategy == RequirementsStrategy.RAISE:
+                    raise RequirementsMismatch(f"There are extra requirements in repository {repo}, branch {branch}.",
+                                               diff=requirements.read_text())
+
+                self.install_requirements(fl=requirements)
+
+        # requirements for current environment configured and exists
+        else:
+            current_requirements = Path(self.current_environment_requirements)
+
+            current_requirements_set = self.get_requirements_set(current_requirements)
+
+            if not requirements.exists():
+                return  # no req. file in repo -> no extra requirements
+
+            requirements_set = self.get_requirements_set(requirements)
+
+            # only requirements that are extra in repository requirements matter
+            extra_requirements_set = requirements_set - current_requirements_set
+
+            if len(extra_requirements_set) == 0:
+                return  # no extra requirements in repository
+            else:
+                if self.requirements_strategy == RequirementsStrategy.RAISE:
+                    raise RequirementsMismatch(f"There are extra requirements in repository {repo}, branch {branch}.",
+                                               diff="\n".join(extra_requirements_set))
+
+                elif self.requirements_strategy == RequirementsStrategy.INSTALL_EXTRA:
+                    self.install_requirements(requirements=extra_requirements_set)
+
+    def _uninstall(self, *args):
+        self.install_requirements(requirements=args, _action="uninstall")

--- a/arca/exceptions.py
+++ b/arca/exceptions.py
@@ -28,3 +28,10 @@ class PushToRegistryError(ArcaException):
 
 class FileOutOfRangeError(ValueError, ArcaException):
     pass
+
+
+class RequirementsMismatch(ValueError, ArcaException):
+
+    def __init__(self, *args, diff=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.diff = diff

--- a/arca/utils.py
+++ b/arca/utils.py
@@ -1,6 +1,6 @@
 import importlib
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Callable
 
 from .exceptions import ArcaMisconfigured
 
@@ -24,9 +24,10 @@ def load_class(location: str) -> type:
 
 
 class LazySettingProperty:
-    def __init__(self, *, key, default=NOT_SET) -> None:
+    def __init__(self, *, key, default=NOT_SET, convert: Callable=None) -> None:
         self.key = key
         self.default = default
+        self.convert = convert
 
     def __set_name__(self, cls, name):
         self.name = name
@@ -35,6 +36,10 @@ class LazySettingProperty:
         if instance is None or (hasattr(instance, "_arca") and instance._arca is None):
             return self
         result = instance.get_setting(self.key, self.default)
+
+        if self.convert is not None:
+            result = self.convert(result)
+
         setattr(instance, self.name, result)
         return result
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,57 @@
+import os
+
+
+if os.environ.get("TRAVIS", False):
+    BASE_DIR = "/home/travis/build/{}/test_loc".format(os.environ.get("TRAVIS_REPO_SLUG", "mikicz/arca"))
+else:
+    BASE_DIR = "/tmp/arca/test"
+
+RETURN_STR_FUNCTION = """
+def return_str_function():
+    return "Some string"
+"""
+
+SECOND_RETURN_STR_FUNCTION = """
+def return_str_function():
+    return "Some other string"
+"""
+
+RETURN_DJANGO_VERSION_FUNCTION = """
+import django
+
+def return_str_function():
+    return django.__version__
+"""
+
+RETURN_PYTHON_VERSION_FUNCTION = """
+import sys
+
+def return_python_version():
+    return "{}.{}.{}".format(sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
+"""
+
+RETURN_IS_XSLTPROC_INSTALLED = """
+import subprocess
+
+def return_is_xsltproc_installed():
+    try:
+        return subprocess.Popen(["xsltpoc", "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE).wait()
+    except:
+        return False
+"""
+
+RETURN_IS_LXML_INSTALLED = """
+def return_is_lxml_installed():
+    try:
+        import lxml
+        return True
+    except:
+        return False
+"""
+
+RETURN_PLATFORM = """
+import platform
+
+def return_platform():
+    return platform.dist()[0]
+"""

--- a/tests/test_current_environment.py
+++ b/tests/test_current_environment.py
@@ -1,0 +1,273 @@
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from git import Repo
+
+from arca import Arca, CurrentEnvironmentBackend, RequirementsStrategy, Task
+from arca.exceptions import ArcaMisconfigured, BuildError, RequirementsMismatch
+
+from common import BASE_DIR, RETURN_STR_FUNCTION, RETURN_DJANGO_VERSION_FUNCTION
+
+
+def test_current_environment_requirements():
+    # current_environment_requirements is required
+    with pytest.raises(KeyError):
+        Arca(backend=CurrentEnvironmentBackend(verbosity=2), base_dir=BASE_DIR)
+
+    requirements_path = str(uuid4()) + ".txt"
+
+    # no such file exists
+    with pytest.raises(ArcaMisconfigured):
+        Arca(backend=CurrentEnvironmentBackend(
+            verbosity=2,
+            current_environment_requirements=requirements_path
+        ), base_dir=BASE_DIR)
+
+    requirements_path = Path(BASE_DIR) / requirements_path
+    requirements_path.touch()
+
+    # ok when the file exists
+    Arca(backend=CurrentEnvironmentBackend(
+        verbosity=2,
+        current_environment_requirements=requirements_path
+    ), base_dir=BASE_DIR)
+
+    # ok when it's set there's no requirements file
+    arca = Arca(backend=CurrentEnvironmentBackend(
+        verbosity=2,
+        current_environment_requirements=None
+    ), base_dir=BASE_DIR)
+
+    # test how installing nonexisting packages is handled
+    with pytest.raises(BuildError):
+        arca.backend.install_requirements(requirements=[str(uuid4())])
+
+    with pytest.raises(ValueError):
+        arca.backend.install_requirements()
+
+    with pytest.raises(ValueError):
+        arca.backend.install_requirements(requirements=["django"], _action="remove")
+
+
+@pytest.mark.parametrize("strategy", ["ignore", RequirementsStrategy.IGNORE])
+def test_strategy_ignore(mocker, strategy):
+    install_requirements = mocker.patch.object(CurrentEnvironmentBackend, "install_requirements")
+
+    arca = Arca(backend=CurrentEnvironmentBackend(
+        verbosity=2,
+        current_environment_requirements=None,
+        requirements_strategy=strategy
+    ), base_dir=BASE_DIR)
+
+    git_dir = Path("/tmp/arca/") / str(uuid4())
+    repo = Repo.init(git_dir)
+    filepath = git_dir / "test_file.py"
+    repo_url = f"file://{git_dir}"
+    branch = "master"
+
+    filepath.write_text(RETURN_STR_FUNCTION)
+    repo.index.add([str(filepath)])
+    repo.index.commit("Initial")
+
+    task = Task(
+        "return_str_function",
+        from_imports=[("test_file", "return_str_function")]
+    )
+
+    # nor the current env or the repo has any requirements, install requirements is not called at all
+    assert arca.run(repo_url, branch, task).output == "Some string"
+    assert install_requirements.call_count == 0
+
+    repo.create_head("no_requirements")  # keep a reference to when the repo had no requirements, needed later
+    repo.branches.master.checkout()
+
+    requirements_path = git_dir / arca.backend.requirements_location
+    requirements_path.parent.mkdir(exist_ok=True, parents=True)
+
+    with requirements_path.open("w") as fl:
+        fl.write("django==1.11.4")
+    with filepath.open("w") as fl:
+        fl.write(RETURN_DJANGO_VERSION_FUNCTION)
+
+    repo.index.add([str(filepath)])
+    repo.index.add([str(requirements_path)])
+    repo.index.commit("Added requirements, changed to version")
+
+    # now the repository has got requirements
+    # install still not called but the task should fail because django is not installed
+    with pytest.raises(BuildError):
+        arca.run(repo_url, branch, task)
+    assert install_requirements.call_count == 0
+
+    current_env_requirements = Path(BASE_DIR) / (str(uuid4()) + ".txt")
+    with current_env_requirements.open("w") as fl:
+        fl.write("django==1.11.4")
+
+    arca = Arca(backend=CurrentEnvironmentBackend(
+        verbosity=2,
+        current_environment_requirements=str(current_env_requirements.resolve()),
+        requirements_strategy=strategy
+    ), base_dir=BASE_DIR)
+
+    # now both the current env and the repo have requirements
+    # install still not called but the task should fail because django is not installed
+    with pytest.raises(BuildError):
+        arca.run(repo_url, branch, task)
+    assert install_requirements.call_count == 0
+
+    # even when the requirements are not the same
+    with current_env_requirements.open("w") as fl:
+        fl.write("six")
+    with pytest.raises(BuildError):
+        arca.run(repo_url, branch, task)
+    assert install_requirements.call_count == 0
+
+    # and now we test everything still works when the req. file is missing from repo
+    assert arca.run(repo_url, "no_requirements", task).output == "Some string"
+    assert install_requirements.call_count == 0
+
+
+@pytest.mark.parametrize("strategy", ["raise", RequirementsStrategy.RAISE])
+def test_strategy_raise(strategy):
+    arca = Arca(backend=CurrentEnvironmentBackend(
+        verbosity=2,
+        current_environment_requirements=None,
+        requirements_strategy=strategy
+    ), base_dir=BASE_DIR)
+
+    git_dir = Path("/tmp/arca/") / str(uuid4())
+    repo = Repo.init(git_dir)
+    filepath = git_dir / "test_file.py"
+    repo_url = f"file://{git_dir}"
+    branch = "master"
+
+    filepath.write_text(RETURN_STR_FUNCTION)
+    repo.index.add([str(filepath)])
+    repo.index.commit("Initial")
+
+    task = Task(
+        "return_str_function",
+        from_imports=[("test_file", "return_str_function")]
+    )
+
+    # nor the current env or the repo has any requirements, install requirements is not called at all
+    assert arca.run(repo_url, branch, task).output == "Some string"
+
+    repo.create_head("no_requirements")  # keep a reference to when the repo had no requirements, needed later
+    repo.branches.master.checkout()
+
+    requirements_path = git_dir / arca.backend.requirements_location
+    requirements_path.parent.mkdir(exist_ok=True, parents=True)
+
+    with requirements_path.open("w") as fl:
+        fl.write("django==1.11.4")
+    with filepath.open("w") as fl:
+        fl.write(RETURN_DJANGO_VERSION_FUNCTION)
+
+    repo.index.add([str(filepath)])
+    repo.index.add([str(requirements_path)])
+    repo.index.commit("Added requirements, changed to version")
+
+    # Run should raise a exception because there's now extra requirements in the repo
+    with pytest.raises(RequirementsMismatch):
+        arca.run(repo_url, branch, task)
+
+    current_env_requirements = Path(BASE_DIR) / (str(uuid4()) + ".txt")
+    with current_env_requirements.open("w") as fl:
+        fl.write("django==1.11.4")
+
+    arca = Arca(backend=CurrentEnvironmentBackend(
+        verbosity=2,
+        current_environment_requirements=str(current_env_requirements.resolve()),
+        requirements_strategy=strategy
+    ), base_dir=BASE_DIR)
+
+    # now both the current env and the repo have the same requirements
+    # run should fail not because of mismatch, but because django is not actually installed
+    with pytest.raises(BuildError):
+        arca.run(repo_url, branch, task)
+
+    # an extra requirement when current env. reqs. are set
+    with current_env_requirements.open("w") as fl:
+        fl.write("six")
+    with pytest.raises(RequirementsMismatch):
+        arca.run(repo_url, branch, task)
+
+    # and now we test everything still works when the req. file is missing from repo but env. reqs. are set
+    assert arca.run(repo_url, "no_requirements", task).output == "Some string"
+
+
+@pytest.mark.parametrize("strategy", ["install_extra", RequirementsStrategy.INSTALL_EXTRA])
+def test_strategy_install_extra(mocker, strategy):
+    install_requirements = mocker.spy(CurrentEnvironmentBackend, "install_requirements")
+
+    arca = Arca(backend=CurrentEnvironmentBackend(
+        verbosity=2,
+        current_environment_requirements=None,
+        requirements_strategy=strategy
+    ), base_dir=BASE_DIR)
+
+    git_dir = Path("/tmp/arca/") / str(uuid4())
+    repo = Repo.init(git_dir)
+    filepath = git_dir / "test_file.py"
+    repo_url = f"file://{git_dir}"
+    branch = "master"
+
+    filepath.write_text(RETURN_STR_FUNCTION)
+    repo.index.add([str(filepath)])
+    repo.index.commit("Initial")
+
+    task = Task(
+        "return_str_function",
+        from_imports=[("test_file", "return_str_function")]
+    )
+
+    # nor the current env or the repo has any requirements, install requirements is not called at all
+    assert arca.run(repo_url, branch, task).output == "Some string"
+    assert install_requirements.call_count == 0
+
+    repo.create_head("no_requirements")  # keep a reference to when the repo had no requirements, needed later
+    repo.branches.master.checkout()
+
+    requirements_path = git_dir / arca.backend.requirements_location
+    requirements_path.parent.mkdir(exist_ok=True, parents=True)
+
+    with requirements_path.open("w") as fl:
+        fl.write("django==1.11.4")
+    with filepath.open("w") as fl:
+        fl.write(RETURN_DJANGO_VERSION_FUNCTION)
+
+    repo.index.add([str(filepath)])
+    repo.index.add([str(requirements_path)])
+    repo.index.commit("Added requirements, changed to version")
+
+    # Repository now contains a requirement while the current env has none - install is called with whole file
+    assert arca.run(repo_url, branch, task).output == "1.11.4"
+    assert install_requirements.call_count == 1
+
+    current_env_requirements = Path(BASE_DIR) / (str(uuid4()) + ".txt")
+    with current_env_requirements.open("w") as fl:
+        fl.write("django==1.11.4")
+
+    arca = Arca(backend=CurrentEnvironmentBackend(
+        verbosity=2,
+        current_environment_requirements=str(current_env_requirements.resolve()),
+        requirements_strategy=strategy
+    ), base_dir=BASE_DIR)
+
+    # now both the current env and the repo have the same requirements, call count shouldn't increase
+    assert arca.run(repo_url, branch, task).output == "1.11.4"
+    assert install_requirements.call_count == 1
+
+    with current_env_requirements.open("w") as fl:
+        fl.write("six")
+
+    # requirements are now not the same, install is called again
+    assert arca.run(repo_url, branch, task).output == "1.11.4"
+    assert install_requirements.call_count == 2
+
+    # and now we test everything still works when the req. file is missing from repo but env. reqs. are set
+    assert arca.run(repo_url, "no_requirements", task).output == "Some string"
+
+    arca.backend._uninstall("django")

--- a/tests/test_current_environment.py
+++ b/tests/test_current_environment.py
@@ -50,6 +50,27 @@ def test_current_environment_requirements():
         arca.backend.install_requirements(requirements=["django"], _action="remove")
 
 
+def test_requirements_strategy():
+    """ Test validation of invalid strategies
+    """
+
+    with pytest.raises(ValueError):
+        Arca(backend=CurrentEnvironmentBackend(
+            verbosity=2,
+            current_environment_requirements=None,
+            requirements_strategy="nonexistant_strategy"
+        ), base_dir=BASE_DIR)
+
+    with pytest.raises(ValueError):
+        arca = Arca(base_dir=BASE_DIR, settings={
+            "ARCA_BACKEND": "arca.backend.CurrentEnvironmentBackend",
+            "ARCA_BACKEND_VERBOSITY": 2,
+            "ARCA_BACKEND_CURRENT_ENVIRONMENT_REQUIREMENTS": None,
+            "ARCA_BACKEND_REQUIREMENTS_STRATEGY": "nonexistant_strategy"
+        })
+        print(arca.backend.requirements_strategy)
+
+
 @pytest.mark.parametrize("strategy", ["ignore", RequirementsStrategy.IGNORE])
 def test_strategy_ignore(mocker, strategy):
     install_requirements = mocker.patch.object(CurrentEnvironmentBackend, "install_requirements")

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -7,44 +7,10 @@ from datetime import datetime
 from git import Repo
 
 from arca import Arca, DockerBackend, Task
-from test_backends import RETURN_DJANGO_VERSION_FUNCTION, RETURN_STR_FUNCTION, BASE_DIR
-
 from arca.exceptions import ArcaMisconfigured
 
-RETURN_PYTHON_VERSION_FUNCTION = """
-import sys
-
-def return_python_version():
-    return "{}.{}.{}".format(sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
-"""
-
-RETURN_IS_XSLTPROC_INSTALLED = """
-import subprocess
-
-def return_is_xsltproc_installed():
-    try:
-        return subprocess.Popen(["xsltpoc", "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE).wait()
-    except:
-        return False
-"""
-
-
-RETURN_IS_LXML_INSTALLED = """
-def return_is_lxml_installed():
-    try:
-        import lxml
-        return True
-    except:
-        return False
-"""
-
-
-RETURN_PLATFORM = """
-import platform
-
-def return_platform():
-    return platform.dist()[0]
-"""
+from common import (RETURN_DJANGO_VERSION_FUNCTION, RETURN_STR_FUNCTION, BASE_DIR, RETURN_PLATFORM,
+                    RETURN_IS_LXML_INSTALLED, RETURN_PYTHON_VERSION_FUNCTION, RETURN_IS_XSLTPROC_INSTALLED)
 
 
 def test_keep_container_running():

--- a/tests/test_single_pull.py
+++ b/tests/test_single_pull.py
@@ -5,12 +5,12 @@ import os
 import pytest
 from git import Repo
 
-from arca import Arca, DockerBackend, Task, VenvBackend
-from test_backends import RETURN_STR_FUNCTION, SECOND_RETURN_STR_FUNCTION, BASE_DIR
+from arca import Arca, DockerBackend, Task, VenvBackend, CurrentEnvironmentBackend
+from common import RETURN_STR_FUNCTION, SECOND_RETURN_STR_FUNCTION, BASE_DIR
 
 
 @pytest.mark.parametrize(
-    "backend", [VenvBackend, DockerBackend],
+    "backend", [VenvBackend, DockerBackend, CurrentEnvironmentBackend],
 )
 def test_single_pull(mocker, backend):
     if os.environ.get("TRAVIS", False) and backend == VenvBackend:
@@ -19,6 +19,8 @@ def test_single_pull(mocker, backend):
     kwargs = {}
     if backend == DockerBackend:
         kwargs["disable_pull"] = True
+    if backend == CurrentEnvironmentBackend:
+        kwargs["current_environment_requirements"] = None
 
     backend = backend(verbosity=2, **kwargs)
 
@@ -62,7 +64,7 @@ def test_single_pull(mocker, backend):
 
 
 @pytest.mark.parametrize(
-    "backend", [VenvBackend, DockerBackend],
+    "backend", [VenvBackend, DockerBackend, CurrentEnvironmentBackend],
 )
 def test_pull_efficiency(mocker, backend):
     if os.environ.get("TRAVIS", False) and backend == VenvBackend:
@@ -71,6 +73,8 @@ def test_pull_efficiency(mocker, backend):
     kwargs = {}
     if backend == DockerBackend:
         kwargs["disable_pull"] = True
+    if backend == CurrentEnvironmentBackend:
+        kwargs["current_environment_requirements"] = None
 
     backend = backend(verbosity=2, **kwargs)
 


### PR DESCRIPTION
As https://github.com/pyvec/naucse.python.cz/issues/175 requires for naucse to be able to run locally without any non-python dependencies, I created a backend which launches task in the current python environment (so even a new virtualenv isn't needed for the forks), with some extra functionality around requirements (with the default strategy being to raise an exception when requirements don't match)