### PR TITLE
Redirecting stdout and stderr in runner when executing the callables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,8 +100,8 @@ To call the function using Arca, the following example would do so:
   print(result.output)
 
 The code would print ``Hello World!``.
-``result`` would be a ``arca.Result`` instance which currently only has one attribute,
-``output``, with the output of the function call.
+``result`` would be a ``arca.Result`` instance. ``arca.Result`` has three attributes,
+``output`` with the return value of the function call, ``stdout`` and ``stderr`` contain things printed to the standard outputs.
 If the task fails, ``arca.exceptions.BuildError`` would be raised.
 
 By default, the `Current Environment Backend <https://arca.readthedocs.io/en/latest/backends.html#current-environment>`_ is used to run tasks,

--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,8 @@ To call the function using Arca, the following example would do so:
 
 The code would print ``Hello World!``.
 ``result`` would be a ``arca.Result`` instance. ``arca.Result`` has three attributes,
-``output`` with the return value of the function call, ``stdout`` and ``stderr`` contain things printed to the standard outputs.
+``output`` with the return value of the function call, ``stdout`` and ``stderr`` contain things printed to the standard outputs
+(see the section about `Result <http://arca.readthedocs.io/en/latest/tasks.html#result>`_ for more info about the capture of the standard outputs).
 If the task fails, ``arca.exceptions.BuildError`` would be raised.
 
 By default, the `Current Environment Backend <https://arca.readthedocs.io/en/latest/backends.html#current-environment>`_ is used to run tasks,

--- a/arca/_runner.py
+++ b/arca/_runner.py
@@ -1,9 +1,11 @@
 """ This file is the code which actually launches the tasks, the serialized JSONs.
 """
+import contextlib
+import io
 import json
-import traceback
-import sys
 import os
+import sys
+import traceback
 from importlib import import_module
 from pathlib import Path
 
@@ -53,12 +55,19 @@ def run(filename):
     except (ImportError, AttributeError):
         return {"success": False, "reason": "import", "error": traceback.format_exc()}
 
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
     try:
-        res = entry_point(*args, **kwargs)
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            res = entry_point(*args, **kwargs)
     except BaseException:
         return {"success": False, "error": traceback.format_exc()}
 
-    return {"success": True, "result": res}
+    return {"success": True,
+            "result": res,
+            "stdout": stdout.getvalue(),
+            "stderr": stderr.getvalue()}
 
 
 if __name__ == "__main__":

--- a/arca/result.py
+++ b/arca/result.py
@@ -36,3 +36,9 @@ class Result:
 
         #: The output of the task
         self.output = result.get("result")
+
+        #: What the function wrote to stdout
+        self.stdout = result.get("stdout")
+
+        #: What the function wrote to stderr
+        self.stderr = result.get("stderr")

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -42,7 +42,8 @@ To call the function using Arca, the following example would do so:
 The code would print ``Hello World!``.
 
 ``result`` would be a :class:`Result <arca.Result>` instance. :class:`Result <arca.Result>` has three attributes,
-``output`` with the return value of the function call, ``stdout`` and ``stderr`` contain things printed to the standard outputs.
+``output`` with the return value of the function call, ``stdout`` and ``stderr`` contain things printed to the standard outputs
+(see the section about :ref:`Result <result>` for more info about the capture of the standard outputs).
 If the task fails, :class:`arca.exceptions.BuildError` would be raised.
 
 By default, the :ref:`Current Environment Backend <backends_cur>` is used to run tasks,

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -40,8 +40,9 @@ To call the function using Arca, the following example would do so:
   print(result.output)
 
 The code would print ``Hello World!``.
-``result`` would be a :class:`Result <arca.Result>` instance which currently only has one attribute,
-``output``, with the output of the function call.
+
+``result`` would be a :class:`Result <arca.Result>` instance. :class:`Result <arca.Result>` has three attributes,
+``output`` with the return value of the function call, ``stdout`` and ``stderr`` contain things printed to the standard outputs.
 If the task fails, :class:`arca.exceptions.BuildError` would be raised.
 
 By default, the :ref:`Current Environment Backend <backends_cur>` is used to run tasks,

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -69,6 +69,8 @@ The default value is 5 seconds.
 
 When a task exceeds a timeout, :class:`arca.exceptions.BuildTimeoutError` is raised.
 
+.. _result:
+
 Result
 ------
 
@@ -77,3 +79,7 @@ Anything that's json-serializable can be returned from the entrypoints.
 The :class:`arca.Result` instances contain three attributes.
 ``output`` contains the value returned from the entrypoint.
 ``stdout`` and ``stderr`` contain things written to the standard outputs.
+
+Arca uses :func:`contextlib.redirect_stdout` and :func:`contextlib.redirect_stderrr` to catch the standard outputs,
+which only redirect things written from standard Python code -- for example output from a subprocess is not caught.
+Due to the way backends launch tasks the callables cannot output anything that is not redirectable by these two context managers.

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -72,6 +72,8 @@ When a task exceeds a timeout, :class:`arca.exceptions.BuildTimeoutError` is rai
 Result
 ------
 
+The output of a task is stored and returned in a :class:`arca.Result` instance.
 Anything that's json-serializable can be returned from the entrypoints.
-Unfortunately, due to the way tasks are being launched by various backends, the entrypoints **must not** print anything,
-they can only return values.
+The :class:`arca.Result` instances contain three attributes.
+``output`` contains the value returned from the entrypoint.
+``stdout`` and ``stderr`` contain things written to the standard outputs.

--- a/tests/common.py
+++ b/tests/common.py
@@ -64,3 +64,16 @@ def return_str_function():
     time.sleep(2)
     return "Some string"
 """
+
+PRINTING_FUNCTION = """
+import sys
+
+def func():
+    print("Printed to stdout")
+    sys.stdout.write("Written to stdout")
+
+    print("Printed to stderr", file=sys.stderr)
+    sys.stderr.write("Written to stderr")
+
+    return 1
+"""


### PR DESCRIPTION
I had no idea this existed, only learned about it yesterday at Pyvo. This solves one of the questions from the reviewer of the thesis.