### PR TITLE
Raising Arca's exception when building  a docker image fails

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,4 @@
 [flake8]
 max-line-length = 120
+ignore =
+    E252

--- a/arca/backend/base.py
+++ b/arca/backend/base.py
@@ -92,8 +92,9 @@ class BaseBackend:
     def hash_file_contents(requirements_option: RequirementsOptions, path: Path) -> str:
         """ Returns a SHA256 hash of the contents of ``path`` combined with the Arca version.
         """
-        return hashlib.sha256(path.read_bytes() +
-                              bytes(requirements_option.name + arca.__version__, "utf-8")).hexdigest()
+        return hashlib.sha256(path.read_bytes() + bytes(
+            requirements_option.name + arca.__version__, "utf-8"
+        )).hexdigest()
 
     def get_requirements_information(self, path: Path) -> Tuple[RequirementsOptions, Optional[str]]:
         """

--- a/arca/backend/docker.py
+++ b/arca/backend/docker.py
@@ -310,7 +310,10 @@ class DockerBackend(BaseBackend):
                                             f"{self.requirements_timeout} seconds.")
 
             logger.exception(e)
-            raise
+
+            raise BuildError("Building docker image failed, see extra info for details.", extra_info={
+                "build_log": e.build_log
+            })
 
     def get_arca_base(self, pull=True):
         """

--- a/arca/backend/vagrant.py
+++ b/arca/backend/vagrant.py
@@ -184,7 +184,8 @@ class VagrantBackend(DockerBackend):
 
             api.run(f"docker cp /vagrant/{definition_filename} {container_name}:/srv/scripts/")
 
-            output = api.run(" ".join([
+            output = api.run(
+                " ".join([
                     "docker", "exec", container_name,
                     "python", "/srv/scripts/runner.py", f"/srv/scripts/{definition_filename}",
                 ]),

--- a/arca/result.py
+++ b/arca/result.py
@@ -17,7 +17,7 @@ class Result:
                 raise BuildError("The build failed (the output was corrupted, "
                                  "possibly by the callable printing something)",
                                  extra_info={
-                                    "output": output
+                                     "output": output
                                  })
 
         if not isinstance(result, dict):

--- a/tests/fixtures/Pipfile.lock.invalid
+++ b/tests/fixtures/Pipfile.lock.invalid
@@ -1,0 +1,29 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "9b35011920847815507f6f45f846033b3807fbc766951daed28ff05da88f8998"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.6"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "colorama": {
+            "hashes": [
+                "sha256:463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda",
+                "sha256:48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"
+            ],
+            "index": "pypi",
+            "version": "==0.3.8"
+        }
+    },
+    "develop": {}
+}

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -123,6 +123,14 @@ def test_backends(temp_repo_func, backend, requirements_location, file_location)
 
     assert arca.run(temp_repo_func.url, temp_repo_func.branch, task).output == "0.3.9"
 
+    pipfile_lock_path.write_text((Path(__file__).parent / "fixtures/Pipfile.lock.invalid").read_text("utf-8"))
+
+    temp_repo_func.repo.index.add([str(pipfile_lock_path)])
+    temp_repo_func.repo.index.commit("Broke Pipfile.lock")
+
+    with pytest.raises(BuildError):  # Invalid Pipfile.lock
+        arca.run(temp_repo_func.url, temp_repo_func.branch, task)
+
     # cleanup
 
     with pytest.raises(ModuleNotFoundError):


### PR DESCRIPTION
Fixes #56 

The invalid Pipfile.lock was created by copying the valid one in the repo, but changing the version (the same modification which broke naucse).