### PR TITLE
Docker backend: Remove invalid branch characters in container name

### DIFF
--- a/arca/backend/docker.py
+++ b/arca/backend/docker.py
@@ -4,6 +4,7 @@ import platform
 import signal
 import tarfile
 import time
+import re
 
 from io import BytesIO
 from pathlib import Path
@@ -732,9 +733,13 @@ class DockerBackend(BaseBackend):
     def get_container_name(self, repo: str, branch: str, git_repo: Repo):
         """ Returns the name of the container used for the repo.
         """
+
+        # Remove characters that aren't valid in Docker container names
+        branch_string = re.sub('[^a-zA-Z0-9_.-]+', '-', branch)
+
         return "arca_{}_{}_{}".format(
             self._arca.repo_id(repo),
-            branch,
+            branch_string,
             self._arca.current_git_hash(repo, branch, git_repo, short=True)
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,17 +16,26 @@ def create_temp_repo(file) -> TempRepo:
     git_dir = Path(tempfile.mkdtemp())
     repo = Repo.init(str(git_dir))
 
-    return TempRepo(repo, git_dir, f"file://{git_dir}", "master", git_dir / file)
+    return TempRepo(
+        repo, git_dir, f"file://{git_dir}", "master", git_dir / file,
+    )
 
 
-@pytest.fixture()
-def temp_repo_func():
+@pytest.fixture(params=["master", "branch/with/slash"])
+def temp_repo_func(request):
     temp_repo = create_temp_repo("test_file.py")
 
     temp_repo.file_path.write_text(RETURN_STR_FUNCTION)
 
     temp_repo.repo.index.add([str(temp_repo.file_path)])
     temp_repo.repo.index.commit("Initial")
+
+    branch_name = request.param
+    if branch_name != "master":
+        # Now that there is a commit, create a branch
+        temp_repo = temp_repo._replace(branch=branch_name)
+        branch = temp_repo.repo.create_head(branch_name)
+        temp_repo.repo.head.reference = branch
 
     yield temp_repo
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -68,7 +68,7 @@ def test_backends(temp_repo_func, backend, requirements_location, file_location)
     # test that tags work as well
     assert arca.run(temp_repo_func.url, "test_tag", task).output == "Some string"
 
-    temp_repo_func.repo.branches.master.checkout()
+    temp_repo_func.repo.branches[temp_repo_func.branch].checkout()
 
     requirements_path = temp_repo_func.repo_path / backend.requirements_location
     requirements_path.parent.mkdir(exist_ok=True, parents=True)

--- a/tests/test_current_environment.py
+++ b/tests/test_current_environment.py
@@ -85,7 +85,7 @@ def test_current_environment_backend(temp_repo_func, requirements_location, file
     # test that tags work as well
     assert arca.run(temp_repo_func.url, "test_tag", task).output == "Some string"
 
-    temp_repo_func.repo.branches.master.checkout()
+    temp_repo_func.repo.branches[temp_repo_func.branch].checkout()
 
     requirements_path = temp_repo_func.repo_path / backend.requirements_location
     requirements_path.parent.mkdir(exist_ok=True, parents=True)

--- a/tests/test_vagrant.py
+++ b/tests/test_vagrant.py
@@ -106,7 +106,7 @@ def test_vagrant(temp_repo_func, destroy=False):
     assert arca.run(temp_repo_func.url, "branch", task).output == TEST_UNICODE
 
     # test timeout
-    temp_repo_func.repo.branches.master.checkout()
+    temp_repo_func.repo.branches[temp_repo_func.branch].checkout()
     temp_repo_func.file_path.write_text(WAITING_FUNCTION)
     temp_repo_func.repo.index.add([str(temp_repo_func.file_path)])
     temp_repo_func.repo.index.commit("Waiting function")


### PR DESCRIPTION
This aims to make it possible to use branches with slashes in their names.

I don't have all the test dependencies locally, so submitting I'm this for Travis.

Fixes: https://github.com/pyvec/arca/issues/79